### PR TITLE
Ironing Out the Ruff Spots in Our Concurrency Wardrobe

### DIFF
--- a/src/unirun/api.py
+++ b/src/unirun/api.py
@@ -98,7 +98,9 @@ def process_executor(*, max_workers: int | None = None) -> Executor:
     return get_process_pool(max_workers=max_workers)
 
 
-def interpreter_executor(*, max_workers: int | None = None, isolated: bool = True) -> Executor:
+def interpreter_executor(
+    *, max_workers: int | None = None, isolated: bool = True
+) -> Executor:
     """Return an executor backed by sub-interpreters (falls back to threads).
 
     >>> from unirun import reset

--- a/src/unirun/benchmarks.py
+++ b/src/unirun/benchmarks.py
@@ -1,14 +1,12 @@
+"""Compatibility shims for the optional benchmark helpers."""
+
 from __future__ import annotations
 
-"""Compatibility shims for the optional benchmark helpers.
-
-The real implementation lives in ``unirun_bench.engine`` so that importing the
-core ``unirun`` package does not eagerly pull in the benchmark machinery. The
-functions defined here re-export that implementation on demand.
-"""
-
 from importlib import import_module
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from unirun_bench.engine import BenchmarkRecord, Scenario, format_table, run_suite
 
 __all__ = ["run_suite", "format_table", "BenchmarkRecord", "Scenario"]
 
@@ -17,7 +15,7 @@ def _load() -> Any:
     return import_module("unirun_bench.engine")
 
 
-def __getattr__(name: str) -> Any:  # pragma: no cover - exercised indirectly via imports
+def __getattr__(name: str) -> Any:  # pragma: no cover - import indirection
     module = _load()
     try:
         return getattr(module, name)

--- a/src/unirun/executors/process.py
+++ b/src/unirun/executors/process.py
@@ -39,7 +39,9 @@ def get_process_pool(
 
     with _LOCK:
         if _PROCESS_POOL is None:
-            ctx = multiprocessing.get_context(desired_context) if desired_context else None
+            ctx = None
+            if desired_context:
+                ctx = multiprocessing.get_context(desired_context)
             _PROCESS_POOL = ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx)
             _record_pool_metadata(context=desired_context, pool=_PROCESS_POOL)
             _register_atexit()

--- a/src/unirun/executors/threading.py
+++ b/src/unirun/executors/threading.py
@@ -30,7 +30,10 @@ def get_thread_pool(
         if _THREAD_POOL is not None:
             if max_workers is not None and max_workers != _THREAD_POOL_MAX_WORKERS:
                 should_reset = True
-            elif thread_name_prefix is not None and desired_prefix != _THREAD_POOL_PREFIX:
+            elif (
+                thread_name_prefix is not None
+                and desired_prefix != _THREAD_POOL_PREFIX
+            ):
                 should_reset = True
 
     if should_reset:

--- a/src/unirun/scheduler.py
+++ b/src/unirun/scheduler.py
@@ -108,13 +108,19 @@ class Scheduler:
 
         cpu_bound = hints.get("cpu_bound", config.cpu_bound)
         io_bound = hints.get("io_bound", config.io_bound)
-        prefer_sub = hints.get("prefers_subinterpreters", config.prefers_subinterpreters)
+        prefer_sub = hints.get(
+            "prefers_subinterpreters",
+            config.prefers_subinterpreters,
+        )
 
         if prefer_sub and self._capabilities.supports_subinterpreters:
             return "subinterpreter"
 
         if cpu_bound:
-            if not self._capabilities.gil_enabled or self._capabilities.free_threading_build:
+            if (
+                not self._capabilities.gil_enabled
+                or self._capabilities.free_threading_build
+            ):
                 return "thread"
             return "process"
 
@@ -129,12 +135,18 @@ class Scheduler:
         if mode == "thread":
             configured_workers = self._config.max_workers
             suggested_workers = self._capabilities.suggested_io_workers
-            max_workers = hints.get("max_workers", configured_workers or suggested_workers)
+            max_workers = hints.get(
+                "max_workers",
+                configured_workers or suggested_workers,
+            )
             return get_thread_pool(max_workers=max_workers)
         if mode == "process":
             configured_workers = self._config.max_workers
             suggested_workers = self._capabilities.suggested_process_workers
-            max_workers = hints.get("max_workers", configured_workers or suggested_workers)
+            max_workers = hints.get(
+                "max_workers",
+                configured_workers or suggested_workers,
+            )
             return get_process_pool(max_workers=max_workers)
         if mode == "subinterpreter":
             return get_interpreter_executor(max_workers=hints.get("max_workers"))
@@ -170,7 +182,14 @@ def submit(executor: Executor, func: Any, /, *args: Any, **kwargs: Any):
     return async_bridge.submit(executor, func, *args, **kwargs)
 
 
-def map(executor: Executor, func: Any, iterable: Any, /, *args: Any, timeout: float | None = None):
+def map(
+    executor: Executor,
+    func: Any,
+    iterable: Any,
+    /,
+    *args: Any,
+    timeout: float | None = None,
+):
     return async_bridge.map(executor, func, iterable, *args, timeout=timeout)
 
 

--- a/src/unirun_bench/engine.py
+++ b/src/unirun_bench/engine.py
@@ -25,7 +25,12 @@ class Scenario(ABC):
     description: str
 
     @abstractmethod
-    def args(self, *, limit: int, duration: float) -> tuple[tuple, dict]:  # pragma: no cover - abstract
+    def args(
+        self,
+        *,
+        limit: int,
+        duration: float,
+    ) -> tuple[tuple, dict]:  # pragma: no cover - abstract
         """Return positional and keyword arguments for the underlying workload."""
 
 
@@ -33,7 +38,12 @@ class Scenario(ABC):
 class CpuScenario(Scenario):
     """CPU-bound benchmark that counts primes using a naive sieve."""
 
-    def args(self, *, limit: int, duration: float) -> tuple[tuple, dict]:  # noqa: D401
+    def args(
+        self,
+        *,
+        limit: int,
+        duration: float,
+    ) -> tuple[tuple, dict]:  # noqa: D401
         return (limit,), {}
 
 
@@ -41,7 +51,12 @@ class CpuScenario(Scenario):
 class IoScenario(Scenario):
     """IO-bound benchmark that sleeps for a configurable duration."""
 
-    def args(self, *, limit: int, duration: float) -> tuple[tuple, dict]:  # noqa: D401
+    def args(
+        self,
+        *,
+        limit: int,
+        duration: float,
+    ) -> tuple[tuple, dict]:  # noqa: D401
         return (duration,), {}
 
 
@@ -278,7 +293,10 @@ def _measure_stdlib_sync(
     for _ in range(samples):
         start = time.perf_counter()
         with _create_stdlib_executor(scenario) as executor:
-            futures = [executor.submit(func, *args, **kwargs) for _ in range(scenario.parallelism)]
+            futures = [
+                executor.submit(func, *args, **kwargs)
+                for _ in range(scenario.parallelism)
+            ]
             for future in futures:
                 future.result()
         durations.append((time.perf_counter() - start) * 1000.0)
@@ -313,7 +331,9 @@ def _measure_stdlib_async(
     return asyncio.run(_runner())
 
 
-def _create_stdlib_executor(scenario: Scenario) -> ThreadPoolExecutor | ProcessPoolExecutor:
+def _create_stdlib_executor(
+    scenario: Scenario,
+) -> ThreadPoolExecutor | ProcessPoolExecutor:
     if isinstance(scenario, IoScenario):
         return ThreadPoolExecutor(
             max_workers=scenario.parallelism,
@@ -323,11 +343,19 @@ def _create_stdlib_executor(scenario: Scenario) -> ThreadPoolExecutor | ProcessP
 
 
 def _stdlib_sync_mode(scenario: Scenario) -> str:
-    return "stdlib.thread.sync" if isinstance(scenario, IoScenario) else "stdlib.process.sync"
+    return (
+        "stdlib.thread.sync"
+        if isinstance(scenario, IoScenario)
+        else "stdlib.process.sync"
+    )
 
 
 def _stdlib_async_mode(scenario: Scenario) -> str:
-    return "stdlib.thread.async" if isinstance(scenario, IoScenario) else "stdlib.process.async"
+    return (
+        "stdlib.thread.async"
+        if isinstance(scenario, IoScenario)
+        else "stdlib.process.async"
+    )
 
 
 def _dispatch_function(scenario: Scenario):
@@ -400,11 +428,19 @@ def format_table(records: Sequence[BenchmarkRecord]) -> str:
             widths[idx] = max(widths[idx], len(value))
     border = " ".join("-" * width for width in widths)
     lines = [border]
-    header_line = " ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    header_line = " ".join(
+        header.ljust(widths[idx])
+        for idx, header in enumerate(headers)
+    )
     lines.append(header_line)
     lines.append(border)
     for row in rows:
-        lines.append(" ".join(value.ljust(widths[idx]) for idx, value in enumerate(row)))
+        lines.append(
+            " ".join(
+                value.ljust(widths[idx])
+                for idx, value in enumerate(row)
+            )
+        )
     lines.append(border)
     return "\n".join(lines)
 

--- a/tests/test_async_bridge.py
+++ b/tests/test_async_bridge.py
@@ -21,7 +21,10 @@ def test_to_thread_uses_shared_executor() -> None:
     assert name.startswith("unirun-thread")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="process pool not exercised on Windows in tests")
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="process pool not exercised on Windows in tests",
+)
 def test_to_process_runs_function() -> None:
     async def runner() -> None:
         result = await to_process(simulate_blocking_io, 0.0)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -77,7 +77,11 @@ def test_format_table_no_records() -> None:
 
 
 @pytest.mark.parametrize("use_json", [False, True])
-def test_cli_outputs(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], use_json: bool) -> None:
+def test_cli_outputs(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    use_json: bool,
+) -> None:
     from unirun_bench import cli
 
     fake_record = BenchmarkRecord(
@@ -114,7 +118,12 @@ def test_select_scenarios_failure() -> None:
 
     from unirun_bench.engine import CpuScenario, _select_scenarios
 
-    scenario = CpuScenario(name="cpu.primes", workload="cpu", parallelism=1, description="")
+    scenario = CpuScenario(
+        name="cpu.primes",
+        workload="cpu",
+        parallelism=1,
+        description="",
+    )
     with pytest.raises(ValueError):
         _select_scenarios([scenario], "invalid")
 
@@ -130,5 +139,17 @@ def test_dispatch_function_error() -> None:
             return (), {}
 
     with pytest.raises(ValueError):
-        _dispatch_function(DummyScenario(name="dummy", workload="test", parallelism=1, description=""))
-    DummyScenario(name="dummy", workload="test", parallelism=1, description="").args(limit=0, duration=0.0)
+        _dispatch_function(
+            DummyScenario(
+                name="dummy",
+                workload="test",
+                parallelism=1,
+                description="",
+            )
+        )
+    DummyScenario(
+        name="dummy",
+        workload="test",
+        parallelism=1,
+        description="",
+    ).args(limit=0, duration=0.0)

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -19,7 +19,10 @@ def test_detect_capabilities_shape() -> None:
 
 
 def test_detect_capabilities_free_threading_branch() -> None:
-    with mock.patch("unirun.capabilities.sysconfig.get_config_var", return_value=1), mock.patch(
+    with mock.patch(
+        "unirun.capabilities.sysconfig.get_config_var",
+        return_value=1,
+    ), mock.patch(
         "unirun.capabilities._is_gil_enabled",
         return_value=False,
     ):

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -6,5 +6,8 @@ import unirun.api
 
 
 def test_unirun_api_doctests() -> None:
-    failure_count, _ = doctest.testmod(unirun.api, optionflags=doctest.NORMALIZE_WHITESPACE)
+    failure_count, _ = doctest.testmod(
+        unirun.api,
+        optionflags=doctest.NORMALIZE_WHITESPACE,
+    )
     assert failure_count == 0

--- a/tests/test_interpreter_executor.py
+++ b/tests/test_interpreter_executor.py
@@ -32,7 +32,12 @@ def test_interpreter_executor_with_module(monkeypatch: pytest.MonkeyPatch) -> No
         def __init__(self) -> None:
             self.create = mock.Mock(side_effect=RuntimeError("unsupported"))
 
-    monkeypatch.setattr(subinterpreter, "interpreters", DummyInterpreters(), raising=False)
+    monkeypatch.setattr(
+        subinterpreter,
+        "interpreters",
+        DummyInterpreters(),
+        raising=False,
+    )
 
     def raiser(*_args: object, **_kwargs: object) -> None:
         raise subinterpreter.SubInterpreterUnavailable("missing support")
@@ -76,13 +81,17 @@ def test_get_interpreter_executor_warns_once(monkeypatch: pytest.MonkeyPatch) ->
     subinterpreter.reset_interpreter_executor()
 
 
-def test_subinterpreter_executor_requires_module(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_subinterpreter_executor_requires_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(subinterpreter, "interpreters", None, raising=False)
     with pytest.raises(subinterpreter.SubInterpreterUnavailable):
         subinterpreter.SubInterpreterExecutor(max_workers=1, isolated=True)
 
 
-def test_subinterpreter_executor_requires_primitives(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_subinterpreter_executor_requires_primitives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
         subinterpreter,
         "interpreters",
@@ -203,7 +212,9 @@ def test_rebuild_exception_success_and_fallback() -> None:
     assert isinstance(fallback, subinterpreter.SubInterpreterExecutionError)
 
 
-def test_warn_subinterpreter_fallback_only_once(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_warn_subinterpreter_fallback_only_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(subinterpreter, "_FALLBACK_WARNED", False)
     with pytest.warns(RuntimeWarning):
         subinterpreter._warn_subinterpreter_fallback("first")
@@ -227,7 +238,9 @@ def test_should_rebuild_detection() -> None:
     assert subinterpreter._should_rebuild(settings, None, True) is False
 
 
-def test_create_subinterpreter_executor_pass_through(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_subinterpreter_executor_pass_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def raising(**_: object) -> subinterpreter.SubInterpreterExecutor:
         raise subinterpreter.SubInterpreterUnavailable("x")
 
@@ -236,7 +249,9 @@ def test_create_subinterpreter_executor_pass_through(monkeypatch: pytest.MonkeyP
         subinterpreter._create_subinterpreter_executor(max_workers=None, isolated=True)
 
 
-def test_create_subinterpreter_executor_wraps_other_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_subinterpreter_executor_wraps_other_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def explode(**_: object) -> subinterpreter.SubInterpreterExecutor:
         raise ValueError("boom")
 
@@ -249,13 +264,20 @@ def test_create_subinterpreter_executor_wraps_other_errors(monkeypatch: pytest.M
 def test_destroy_interpreter_uses_close(monkeypatch: pytest.MonkeyPatch) -> None:
     closer = mock.Mock()
     interpreter = SimpleNamespace(close=closer)
-    monkeypatch.setattr(subinterpreter, "interpreters", SimpleNamespace(destroy=None), raising=False)
+    monkeypatch.setattr(
+        subinterpreter,
+        "interpreters",
+        SimpleNamespace(destroy=None),
+        raising=False,
+    )
     executor = _make_stub_executor()
     executor._destroy_interpreter(interpreter)
     closer.assert_called_once_with()
 
 
-def test_get_interpreter_executor_reuses_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_interpreter_executor_reuses_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     call_count = 0
     fake_executor = object()
 
@@ -264,7 +286,15 @@ def test_get_interpreter_executor_reuses_cached(monkeypatch: pytest.MonkeyPatch)
         call_count += 1
         return fake_executor
 
-    monkeypatch.setattr(subinterpreter, "interpreters", SimpleNamespace(create=lambda **_: None, run_string=lambda *args, **kwargs: None), raising=False)
+    monkeypatch.setattr(
+        subinterpreter,
+        "interpreters",
+        SimpleNamespace(
+            create=lambda **_: None,
+            run_string=lambda *args, **kwargs: None,
+        ),
+        raising=False,
+    )
     monkeypatch.setattr(subinterpreter, "_create_subinterpreter_executor", fake_create)
     monkeypatch.setattr(subinterpreter, "_register_atexit", lambda: None)
     subinterpreter.reset_interpreter_executor()
@@ -276,7 +306,9 @@ def test_get_interpreter_executor_reuses_cached(monkeypatch: pytest.MonkeyPatch)
     subinterpreter.reset_interpreter_executor()
 
 
-def test_subinterpreter_executor_handles_zero_threads(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_subinterpreter_executor_handles_zero_threads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     if subinterpreter.interpreters is None:
         pytest.skip("sub-interpreters unavailable")  # pragma: no cover
     monkeypatch.setattr(subinterpreter, "range", lambda *_: [], raising=False)
@@ -317,7 +349,12 @@ def test_execute_with_run_string_empty_payload(monkeypatch: pytest.MonkeyPatch) 
         fd = int(script.split("os.fdopen(")[1].split(",")[0])
         os.close(fd)
 
-    monkeypatch.setattr(subinterpreter, "interpreters", SimpleNamespace(run_string=fake_run_string), raising=False)
+    monkeypatch.setattr(
+        subinterpreter,
+        "interpreters",
+        SimpleNamespace(run_string=fake_run_string),
+        raising=False,
+    )
     executor = _make_stub_executor()
     with pytest.raises(subinterpreter.SubInterpreterUnavailable):
         executor._execute_with_run_string(object(), simulate_blocking_io, (), {})

--- a/tests/test_process_executor.py
+++ b/tests/test_process_executor.py
@@ -19,7 +19,10 @@ def test_process_executor_returns_singleton() -> None:
     assert first is second
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="process pool hint test skipped on Windows")
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="process pool hint test skipped on Windows",
+)
 def test_process_executor_respects_max_workers_hint() -> None:
     baseline = process_executor(max_workers=1)
     updated = process_executor(max_workers=2)
@@ -27,11 +30,18 @@ def test_process_executor_respects_max_workers_hint() -> None:
     assert getattr(updated, "_max_workers", None) == 2
 
 
-@pytest.mark.skipif(len(multiprocessing.get_all_start_methods()) < 2, reason="no alternate start method available")
+@pytest.mark.skipif(
+    len(multiprocessing.get_all_start_methods()) < 2,
+    reason="no alternate start method available",
+)
 def test_process_executor_resets_on_context_change() -> None:
     reset_process_pool()
     first = get_process_pool(max_workers=1)
-    methods = [method for method in multiprocessing.get_all_start_methods() if method != _DEFAULT_CONTEXT]
+    methods = [
+        method
+        for method in multiprocessing.get_all_start_methods()
+        if method != _DEFAULT_CONTEXT
+    ]
     if not methods:
         pytest.skip("no alternate start method available")  # pragma: no cover
     try:

--- a/tests/test_process_executor_double.py
+++ b/tests/test_process_executor_double.py
@@ -9,7 +9,10 @@ from unirun import process_executor
 from unirun.workloads import count_primes
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="process pool parity test skipped on Windows")
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="process pool parity test skipped on Windows",
+)
 def test_process_executor_matches_stdlib() -> None:
     executor = process_executor(max_workers=1)
     result = executor.submit(count_primes, 300).result()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -24,7 +24,9 @@ def test_run_cpu_bound_prefers_process_executor() -> None:
     trace = scheduler._GLOBAL_SCHEDULER.trace
     assert trace is not None
     caps = scheduler._GLOBAL_SCHEDULER.capabilities
-    expected_mode = "thread" if (not caps.gil_enabled or caps.free_threading_build) else "process"
+    expected_mode = (
+        "thread" if (not caps.gil_enabled or caps.free_threading_build) else "process"
+    )
     assert trace.resolved_mode == expected_mode
 
 
@@ -71,7 +73,9 @@ def test_none_mode_resolves_to_thread() -> None:
     assert executor is thread_executor()
     trace = scheduler._GLOBAL_SCHEDULER.trace
     assert trace is not None
-    assert trace.reason == "automation disabled; defaulting to shared thread pool"
+    assert trace.reason == (
+        "automation disabled; defaulting to shared thread pool"
+    )
 
 
 def test_config_override_forces_process() -> None:
@@ -82,7 +86,9 @@ def test_config_override_forces_process() -> None:
     trace = local_scheduler.trace
     assert trace is not None
     assert trace.resolved_mode == "process"
-    assert trace.reason == "cpu-bound hints or GIL-enabled runtime suggested process pool"
+    assert trace.reason == (
+        "cpu-bound hints or GIL-enabled runtime suggested process pool"
+    )
 
 
 def test_prefers_subinterpreter_when_supported(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -96,27 +102,43 @@ def test_prefers_subinterpreter_when_supported(monkeypatch: pytest.MonkeyPatch) 
     )
     base_scheduler._capabilities = patched_caps
     fake_executor = object()
-    monkeypatch.setattr(subinterpreter, "get_interpreter_executor", lambda **_: fake_executor)
-    monkeypatch.setattr(scheduler, "get_interpreter_executor", lambda **_: fake_executor)
+    monkeypatch.setattr(
+        subinterpreter,
+        "get_interpreter_executor",
+        lambda **_: fake_executor,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "get_interpreter_executor",
+        lambda **_: fake_executor,
+    )
     executor = base_scheduler.get_executor(prefers_subinterpreters=True)
     assert executor is fake_executor
     trace = base_scheduler.trace
     assert trace is not None
     assert trace.resolved_mode == "subinterpreter"
-    assert trace.reason == "caller requested sub-interpreters and runtime supports them"
+    assert trace.reason == (
+        "caller requested sub-interpreters and runtime supports them"
+    )
 
 
 def test_cpu_bound_free_threading_prefers_thread() -> None:
     base_scheduler = scheduler.Scheduler()
     caps = base_scheduler.capabilities
-    patched_caps = dataclasses.replace(caps, gil_enabled=False, free_threading_build=True)
+    patched_caps = dataclasses.replace(
+        caps,
+        gil_enabled=False,
+        free_threading_build=True,
+    )
     base_scheduler._capabilities = patched_caps
     executor = base_scheduler.get_executor(cpu_bound=True)
     assert executor is thread_executor()
     trace = base_scheduler.trace
     assert trace is not None
     assert trace.resolved_mode == "thread"
-    assert trace.reason == "io-bound or free-threaded runtime prefers thread pool"
+    assert trace.reason == (
+        "io-bound or free-threaded runtime prefers thread pool"
+    )
 
 
 def test_config_mode_preference() -> None:

--- a/tests/test_scheduler_double.py
+++ b/tests/test_scheduler_double.py
@@ -18,7 +18,10 @@ def test_run_matches_threadpool_executor() -> None:
     assert value == expected
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="process pool parity test skipped on Windows")
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="process pool parity test skipped on Windows",
+)
 def test_run_matches_process_pool() -> None:
     configure(RuntimeConfig(mode="process", auto=False))
     value = run(count_primes, 300, mode="process")


### PR DESCRIPTION
## Summary
- wrap overlong signatures and string literals so ruff passes across executors, scheduler, and benchmarks modules
- restructure dynamic benchmark exports to keep type checking happy without triggering lint errors
- format test helpers and decorators for clarity while staying within the style guide

## Testing
- `uv run ruff check`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e169806304832d8457dfc51b0e18dc