### PR TITLE
Semantic Sorcery: Girokmoji Polishes Our Release Ritual

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,76 @@
+name: Semantic Release with Girokmoji
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Semantic version segment to bump"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Configure git identity
+        run: |
+          git config user.name "girokmoji"
+          git config user.email "release@girokmoji"
+
+      - name: Install project dependencies
+        run: uv pip install .[benchmark]
+
+      - name: Run test suite
+        run: uv run pytest
+
+      - name: Generate release notes with girokmoji
+        id: girokmoji
+        run: |
+          uvx --from "girokmoji@latest" girokmoji release Unirun \
+            --bump ${{ inputs.bump }} \
+            --repo-dir . > release.md
+          latest_tag="$(git describe --tags --abbrev=0)"
+          echo "tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Push version bump and tags
+        run: |
+          git push origin HEAD:${{ github.ref }}
+          git push origin --tags
+
+      - name: Upload release notes artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: girokmoji-release-note
+          path: release.md
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: release.md
+          tag_name: ${{ steps.girokmoji.outputs.tag }}
+          name: "Unirun ${{ steps.girokmoji.outputs.tag }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -188,3 +188,13 @@ stdlib.
   `submit`, `map`, `as_completed`).
 - Capability detection relies solely on stdlib primitives so that behavior is
   stable across CPython releases and alternative builds (musl, manylinux, etc).
+
+## Release Automation
+
+Trigger the `Semantic Release with Girokmoji` workflow from the Actions tab to generate release notes and version tags automatically.
+
+1. Launch the workflow manually and choose the semantic version segment to bump (`patch`, `minor`, or `major`).
+2. The pipeline installs dependencies with `uv`, executes `uv run pytest`, and then invokes `girokmoji` to create a changelog (`release.md`).
+3. Successful runs push the updated tag back to the repository, upload the changelog as an artifact, and publish a GitHub Release using the generated notes.
+
+This workflow mirrors the reference pipeline in [girokmoji](https://github.com/KMilhan/girokmoji) so future tooling updates stay compatible with our release process.


### PR DESCRIPTION
## Summary
- add a girokmoji-driven semantic release workflow that installs uv, runs tests via `uv run pytest`, targets Python 3.13, bumps versions, and publishes releases
- document the manual trigger and workflow behavior in the README so contributors know how to launch releases, including the `uv run pytest` invocation

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e16aad09cc832dafccf3b1080a06d9