### PR TITLE
CI on the Fly: Matrixing Lint, Test, and Bench Across 3.11-3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install ruff
+      - name: Run Ruff lint
+        run: ruff check .
+
+  test:
+    name: Test (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest
+      - name: Run pytest
+        run: pytest
+
+  benchmark:
+    name: Benchmark (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[benchmark]
+      - name: Run benchmark suite
+        run: python -m unirun_bench --profile all --samples 1 --duration 0.05 --limit 50000 --json


### PR DESCRIPTION
## Summary
- add a dedicated CI workflow that runs linting, testing, and benchmarking jobs in parallel
- exercise Python 3.11 through 3.14 via a strategy matrix so each job validates against every supported interpreter
- install only the tooling required per job and run a lightweight benchmark sweep for fast feedback

## Testing
- `uv run --python 3.11 pytest` *(fails: existing test coverage highlights missing `_measure_unirun_map` helper and capability patch expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68e170a094d0832dba79061069a3e010