### PR TITLE
When Benchmarks Lost the Map (and Found It Again)

### DIFF
--- a/src/unirun_bench/engine.py
+++ b/src/unirun_bench/engine.py
@@ -424,10 +424,136 @@ def _measure_stdlib_submit_async(
     return asyncio.run(_runner())
 
 
+def _measure_unirun_map(
+    *,
+    scenario: Scenario,
+    samples: int,
+    args: tuple,
+    kwargs: dict,
+) -> list[float]:
+    durations: list[float] = []
+    hints = _executor_hints(scenario)
+    func = _dispatch_function(scenario)
+    for _ in range(samples):
+        start = time.perf_counter()
+        executor = get_executor(**hints)
+        list(unirun_map(executor, func, *args, **kwargs))
+        durations.append((time.perf_counter() - start) * 1000.0)
+    reset()
+    return durations
+
+
+def _measure_stdlib_map(
+    *,
+    scenario: Scenario,
+    samples: int,
+    args: tuple,
+    kwargs: dict,
+) -> list[float]:
+    durations: list[float] = []
+    func = _dispatch_function(scenario)
+    for _ in range(samples):
+        start = time.perf_counter()
+        with _create_stdlib_executor(scenario) as executor:
+            list(executor.map(func, *args, **kwargs))
+        durations.append((time.perf_counter() - start) * 1000.0)
+    return durations
+
+
+def _measure_unirun_to_thread(
+    *,
+    scenario: Scenario,
+    samples: int,
+    args: tuple,
+    kwargs: dict,
+) -> list[float]:
+    async def _runner() -> list[float]:
+        durations: list[float] = []
+        func = _dispatch_function(scenario)
+        for _ in range(samples):
+            start = time.perf_counter()
+            await asyncio.gather(
+                *(to_thread(func, *args, **kwargs) for _ in range(scenario.parallelism))
+            )
+            durations.append((time.perf_counter() - start) * 1000.0)
+        reset()
+        return durations
+
+    return asyncio.run(_runner())
+
+
+def _measure_stdlib_to_thread(
+    *,
+    scenario: Scenario,
+    samples: int,
+    args: tuple,
+    kwargs: dict,
+) -> list[float]:
+    async def _runner() -> list[float]:
+        durations: list[float] = []
+        func = _dispatch_function(scenario)
+        for _ in range(samples):
+            start = time.perf_counter()
+            await asyncio.gather(
+                *(asyncio.to_thread(func, *args, **kwargs) for _ in range(scenario.parallelism))
+            )
+            durations.append((time.perf_counter() - start) * 1000.0)
+        return durations
+
+    return asyncio.run(_runner())
+
+
+def _measure_unirun_to_process(
+    *,
+    scenario: Scenario,
+    samples: int,
+    args: tuple,
+    kwargs: dict,
+) -> list[float]:
+    async def _runner() -> list[float]:
+        durations: list[float] = []
+        func = _dispatch_function(scenario)
+        for _ in range(samples):
+            start = time.perf_counter()
+            await asyncio.gather(
+                *(to_process(func, *args, **kwargs) for _ in range(scenario.parallelism))
+            )
+            durations.append((time.perf_counter() - start) * 1000.0)
+        reset()
+        return durations
+
+    return asyncio.run(_runner())
+
+
+def _measure_stdlib_to_process(
+    *,
+    scenario: Scenario,
+    samples: int,
+    args: tuple,
+    kwargs: dict,
+) -> list[float]:
+    async def _runner() -> list[float]:
+        durations: list[float] = []
+        func = _dispatch_function(scenario)
+        for _ in range(samples):
+            start = time.perf_counter()
+            with ProcessPoolExecutor(max_workers=scenario.parallelism) as executor:
+                loop = asyncio.get_running_loop()
+                jobs = [
+                    loop.run_in_executor(executor, partial(func, *args, **kwargs))
+                    for _ in range(scenario.parallelism)
+                ]
+                await asyncio.gather(*jobs)
+            durations.append((time.perf_counter() - start) * 1000.0)
+        return durations
+
+    return asyncio.run(_runner())
+
+
 def _create_stdlib_executor(
     scenario: Scenario,
 ) -> ThreadPoolExecutor | ProcessPoolExecutor:
-    if isinstance(scenario, IoScenario):
+    if scenario.workload == "io":
         return ThreadPoolExecutor(
             max_workers=scenario.parallelism,
             thread_name_prefix="unirun-native",
@@ -438,7 +564,7 @@ def _create_stdlib_executor(
 def _stdlib_sync_mode(scenario: Scenario) -> str:
     return (
         "stdlib.thread.sync"
-        if isinstance(scenario, IoScenario)
+        if scenario.workload == "io"
         else "stdlib.process.sync"
     )
 
@@ -446,8 +572,16 @@ def _stdlib_sync_mode(scenario: Scenario) -> str:
 def _stdlib_async_mode(scenario: Scenario) -> str:
     return (
         "stdlib.thread.async"
-        if isinstance(scenario, IoScenario)
+        if scenario.workload == "io"
         else "stdlib.process.async"
+    )
+
+
+def _stdlib_map_mode(scenario: Scenario) -> str:
+    return (
+        "stdlib.thread.map"
+        if scenario.workload == "io"
+        else "stdlib.process.map"
     )
 
 


### PR DESCRIPTION
## Summary
- restore the missing measurement functions for unirun map, to_thread, and to_process benchmark scenarios
- provide stdlib measurement counterparts and workload-aware labeling so io profiles report thread-backed modes

## Testing
- PYENV_VERSION=3.13.3 pytest

------
https://chatgpt.com/codex/tasks/task_e_68e172d23780832db9ee6d783fc63618