### PR TITLE
Thread the auto needle with compat-powered futures

### DIFF
--- a/src/unirun/__init__.py
+++ b/src/unirun/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
+from . import compat
 from .api import (
     configure,
     get_executor,
@@ -58,6 +59,7 @@ __all__ = [
     "to_process",
     "to_thread",
     "wrap_future",
+    "compat",
 ]
 
 try:

--- a/src/unirun/compat/__init__.py
+++ b/src/unirun/compat/__init__.py
@@ -1,0 +1,39 @@
+"""Compat layer mirroring stdlib concurrency entry points."""
+
+from .futures import (
+    ALL_COMPLETED,
+    FIRST_COMPLETED,
+    FIRST_EXCEPTION,
+    BrokenExecutor,
+    CancelledError,
+    Future,
+    InvalidStateError,
+    ProcessPoolExecutor,
+    ThreadPoolExecutor,
+    TimeoutError,
+    as_completed,
+    stdlib_process_pool_executor,
+    stdlib_thread_pool_executor,
+    wait,
+)
+from .asyncio import to_process, to_thread, wrap_future
+
+__all__ = [
+    "Future",
+    "ThreadPoolExecutor",
+    "ProcessPoolExecutor",
+    "CancelledError",
+    "BrokenExecutor",
+    "InvalidStateError",
+    "as_completed",
+    "wait",
+    "ALL_COMPLETED",
+    "FIRST_COMPLETED",
+    "FIRST_EXCEPTION",
+    "TimeoutError",
+    "stdlib_thread_pool_executor",
+    "stdlib_process_pool_executor",
+    "to_thread",
+    "to_process",
+    "wrap_future",
+]

--- a/src/unirun/compat/asyncio.py
+++ b/src/unirun/compat/asyncio.py
@@ -1,0 +1,43 @@
+"""Async helpers that mirror :mod:`asyncio` entry points."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, ParamSpec, TypeVar
+
+from ..executors import async_bridge
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+
+
+async def to_thread(
+    func: Callable[_P, _T],
+    /,
+    *args: _P.args,
+    **kwargs: _P.kwargs,
+) -> _T:
+    """Delegate to :func:`unirun.executors.async_bridge.to_thread`."""
+
+    return await async_bridge.to_thread(func, *args, **kwargs)
+
+
+async def to_process(
+    func: Callable[_P, _T],
+    /,
+    *args: _P.args,
+    **kwargs: _P.kwargs,
+) -> _T:
+    """Bridge onto the shared process pool from async code."""
+
+    return await async_bridge.to_process(func, *args, **kwargs)
+
+
+def wrap_future(
+    future: Any,
+    *,
+    loop: Any | None = None,
+) -> Awaitable[Any]:
+    """Expose :func:`asyncio.wrap_future` through the compat surface."""
+
+    return async_bridge.wrap_future(future, loop=loop)

--- a/src/unirun/compat/futures.py
+++ b/src/unirun/compat/futures.py
@@ -1,0 +1,215 @@
+"""Drop-in replacements for :mod:`concurrent.futures` backed by the scheduler."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import (
+    ALL_COMPLETED,
+    BrokenExecutor,
+    FIRST_COMPLETED,
+    FIRST_EXCEPTION,
+    CancelledError,
+    Executor,
+    Future,
+    InvalidStateError,
+    ProcessPoolExecutor as _StdProcessPoolExecutor,
+    ThreadPoolExecutor as _StdThreadPoolExecutor,
+    TimeoutError,
+    as_completed as _as_completed,
+    wait as _wait,
+)
+from typing import Any, Tuple, TypeVar
+
+from ..scheduler import ExecutorLease, lease_executor
+
+_T = TypeVar("_T")
+
+
+def _tupled(value: Iterable[object]) -> Tuple[object, ...]:
+    if isinstance(value, tuple):
+        return value
+    return tuple(value)
+
+
+def _should_fallback_to_stdlib(**hints: Any) -> bool:
+    if hints.get("initializer") is not None:
+        return True
+    if hints.get("initargs"):
+        return True
+    if hints.get("mp_context") is not None:
+        return True
+    return False
+
+
+class _CompatExecutor(Executor):
+    """Wrapper exposing stdlib semantics while delegating to managed executors."""
+
+    _delegate: Executor
+    _lease: ExecutorLease | None
+    _owns_executor: bool
+
+    def __init__(self, delegate: Executor, lease: ExecutorLease | None) -> None:
+        self._delegate = delegate
+        self._lease = lease
+        self._owns_executor = bool(lease.owns_executor) if lease is not None else True
+        self._shutdown = False
+        self._max_workers = getattr(delegate, "_max_workers", None)
+
+    def __enter__(self) -> "_CompatExecutor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self.shutdown()
+        return False
+
+    def submit(self, fn: Callable[..., _T], /, *args: Any, **kwargs: Any) -> Future[_T]:
+        if self._shutdown:
+            raise RuntimeError("cannot schedule new futures after shutdown")
+        return self._delegate.submit(fn, *args, **kwargs)
+
+    def map(
+        self,
+        func: Callable[[Any], _T],
+        iterable: Iterable[Any],
+        /,
+        *iterables: Iterable[Any],
+        timeout: float | None = None,
+        chunksize: int = 1,
+    ) -> Iterator[_T]:
+        if self._shutdown:
+            raise RuntimeError("cannot schedule new futures after shutdown")
+        delegate_map = getattr(self._delegate, "map", None)
+        if delegate_map is None:
+            return super().map(func, iterable, *iterables, timeout=timeout)
+        return delegate_map(func, iterable, *iterables, timeout=timeout, chunksize=chunksize)
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        if self._shutdown:
+            return
+        self._shutdown = True
+        if self._owns_executor and hasattr(self._delegate, "shutdown"):
+            self._delegate.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+    @property
+    def delegate(self) -> Executor:
+        return self._delegate
+
+
+class ThreadPoolExecutor(_CompatExecutor):
+    """Compat-aware :class:`ThreadPoolExecutor` replacement."""
+
+    def __init__(
+        self,
+        max_workers: int | None = None,
+        thread_name_prefix: str = "",
+        initializer: Callable[..., object] | None = None,
+        initargs: Iterable[object] = (),
+    ) -> None:
+        materialised_args = _tupled(initargs)
+        if _should_fallback_to_stdlib(
+            initializer=initializer,
+            initargs=materialised_args,
+        ):
+            delegate = stdlib_thread_pool_executor(
+                max_workers=max_workers,
+                thread_name_prefix=thread_name_prefix,
+                initializer=initializer,
+                initargs=materialised_args,
+            )
+            super().__init__(delegate, None)
+            return
+        lease = lease_executor(
+            mode="thread",
+            max_workers=max_workers,
+            name=thread_name_prefix or None,
+        )
+        super().__init__(lease.executor, lease)
+
+
+class ProcessPoolExecutor(_CompatExecutor):
+    """Compat-aware :class:`ProcessPoolExecutor` replacement."""
+
+    def __init__(
+        self,
+        max_workers: int | None = None,
+        mp_context: Any | None = None,
+        initializer: Callable[..., object] | None = None,
+        initargs: Iterable[object] = (),
+    ) -> None:
+        materialised_args = _tupled(initargs)
+        if _should_fallback_to_stdlib(
+            mp_context=mp_context,
+            initializer=initializer,
+            initargs=materialised_args,
+        ):
+            delegate = stdlib_process_pool_executor(
+                max_workers=max_workers,
+                mp_context=mp_context,
+                initializer=initializer,
+                initargs=materialised_args,
+            )
+            super().__init__(delegate, None)
+            return
+        lease = lease_executor(
+            mode="process",
+            max_workers=max_workers,
+        )
+        super().__init__(lease.executor, lease)
+
+
+def as_completed(fs: Iterable[Future[_T]], timeout: float | None = None):
+    return _as_completed(fs, timeout=timeout)
+
+
+def wait(
+    fs: Iterable[Future[Any]],
+    timeout: float | None = None,
+    return_when: str = ALL_COMPLETED,
+):
+    return _wait(fs, timeout=timeout, return_when=return_when)
+
+
+__all__ = [
+    "ThreadPoolExecutor",
+    "ProcessPoolExecutor",
+    "Future",
+    "CancelledError",
+    "TimeoutError",
+    "BrokenExecutor",
+    "InvalidStateError",
+    "as_completed",
+    "wait",
+    "ALL_COMPLETED",
+    "FIRST_COMPLETED",
+    "FIRST_EXCEPTION",
+    "stdlib_thread_pool_executor",
+    "stdlib_process_pool_executor",
+]
+
+
+def stdlib_thread_pool_executor(
+    max_workers: int | None = None,
+    thread_name_prefix: str = "",
+    initializer: Callable[..., object] | None = None,
+    initargs: Iterable[object] = (),
+) -> _StdThreadPoolExecutor:
+    return _StdThreadPoolExecutor(
+        max_workers=max_workers,
+        thread_name_prefix=thread_name_prefix,
+        initializer=initializer,
+        initargs=_tupled(initargs),
+    )
+
+
+def stdlib_process_pool_executor(
+    max_workers: int | None = None,
+    mp_context: Any | None = None,
+    initializer: Callable[..., object] | None = None,
+    initargs: Iterable[object] = (),
+) -> _StdProcessPoolExecutor:
+    return _StdProcessPoolExecutor(
+        max_workers=max_workers,
+        mp_context=mp_context,
+        initializer=initializer,
+        initargs=_tupled(initargs),
+    )

--- a/tests/compat/test_asyncio_bridge.py
+++ b/tests/compat/test_asyncio_bridge.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Iterator
+
+import pytest
+
+from unirun import reset
+from unirun.compat import asyncio as compat_asyncio
+
+
+@pytest.fixture(autouse=True)
+def reset_scheduler() -> Iterator[None]:
+    """Guarantee bridge helpers use fresh executor state each run."""
+    reset(cancel_futures=True)
+    yield
+    reset(cancel_futures=True)
+
+
+async def _compute(value: int) -> int:
+    """Async helper multiplying a value via compat.to_thread."""
+    return await compat_asyncio.to_thread(lambda: value * 2)
+
+
+def test_to_thread_matches_asyncio_contract() -> None:
+    """Compat to_thread should mirror asyncio.to_thread semantics."""
+    result = asyncio.run(_compute(6))
+    assert result == 12
+
+
+def test_wrap_future_round_trips_sync_future() -> None:
+    """Ensure wrap_future hands async control back to the loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        future = loop.run_in_executor(None, lambda: 5)
+        wrapped = compat_asyncio.wrap_future(future, loop=loop)
+        result = loop.run_until_complete(wrapped)
+        assert result == 5
+    finally:
+        loop.close()

--- a/tests/compat/test_process_pool_executor.py
+++ b/tests/compat/test_process_pool_executor.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import math
+import multiprocessing as mp
+import os
+import sys
+from concurrent.futures import ProcessPoolExecutor as StdProcessPoolExecutor
+from typing import Iterator
+
+import pytest
+
+from unirun import last_decision, reset
+from unirun.compat import ProcessPoolExecutor
+
+
+@pytest.fixture(autouse=True)
+def reset_scheduler() -> Iterator[None]:
+    """Reset managed pools so process workers do not leak between tests."""
+    reset(cancel_futures=True)
+    yield
+    reset(cancel_futures=True)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="process pools are flaky on windows CI")
+def test_process_pool_executor_resolves_via_scheduler() -> None:
+    """Compat executor should honour scheduler heuristics for processes."""
+    with ProcessPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(math.sqrt, 16)
+        assert future.result() == pytest.approx(4.0)
+
+    trace = last_decision()
+    assert trace is not None
+    assert trace.resolved_mode == "process"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="process pools are flaky on windows CI")
+def test_process_pool_executor_initializer_requests_stdlib() -> None:
+    """Initializer support is routed through the stdlib pool implementation."""
+    context = mp.get_context("spawn")
+
+    with ProcessPoolExecutor(initializer=os.getpid, max_workers=1, mp_context=context) as executor:
+        future = executor.submit(math.sqrt, 9)
+        assert future.result() == pytest.approx(3.0)
+        assert isinstance(executor.delegate, StdProcessPoolExecutor)
+
+    assert last_decision() is None

--- a/tests/compat/test_thread_pool_executor.py
+++ b/tests/compat/test_thread_pool_executor.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import threading
+from typing import Iterator
+
+import pytest
+
+from unirun import last_decision, reset
+from unirun.compat import ThreadPoolExecutor
+
+
+@pytest.fixture(autouse=True)
+def reset_scheduler() -> Iterator[None]:
+    """Ensure pools are fresh for every test to avoid cross-test bleed."""
+    reset(cancel_futures=True)
+    yield
+    reset(cancel_futures=True)
+
+
+def test_thread_pool_executor_records_scheduler_trace() -> None:
+    """Compat executor should leave a scheduler trace for observability."""
+    with ThreadPoolExecutor(max_workers=2, thread_name_prefix="compat-thread") as executor:
+        future = executor.submit(lambda: threading.current_thread().name)
+        thread_name = future.result()
+
+    trace = last_decision()
+    assert trace is not None
+    assert trace.resolved_mode == "thread"
+    assert "compat-thread" in thread_name
+
+
+def test_thread_pool_executor_initializer_triggers_stdlib_fallback() -> None:
+    """Initializers require the stdlib executor for feature parity."""
+    seen: list[str] = []
+
+    def _initializer() -> None:
+        seen.append(threading.current_thread().name)
+
+    with ThreadPoolExecutor(initializer=_initializer) as executor:
+        executor.submit(lambda: None).result()
+
+    assert seen


### PR DESCRIPTION
## Summary
- add `unirun.compat` with futures/asyncio shims that delegate to the scheduler while preserving stdlib escape hatches
- expose the compat surface from the package root so drop-in imports keep working
- cover executor lifecycle and async bridging with focused compat tests

## Testing
- uv run pytest tests/compat

------
https://chatgpt.com/codex/tasks/task_e_68e49074c0c4832dad9036d9b9c35f05