### PR TITLE
Keep Calm and UV On the Pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .
-          pip install ruff
-      - name: Run Ruff lint
-        run: ruff check .
+      - name: Sync dependencies
+        run: uv sync --group dev --locked --python ${{ matrix.python-version }}
+      - name: Run lint suite
+        run: make lint-check
 
   test:
     name: Test (py${{ matrix.python-version }})
@@ -39,18 +35,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .
-          pip install pytest
+      - name: Sync dependencies
+        run: uv sync --group dev --locked --python ${{ matrix.python-version }}
       - name: Run pytest
-        run: pytest
+        run: make test
 
   benchmark:
     name: Benchmark (py${{ matrix.python-version }})
@@ -62,14 +54,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[benchmark]
+      - name: Sync dependencies
+        run: uv sync --extra benchmark --locked --python ${{ matrix.python-version }}
       - name: Run benchmark suite
-        run: python -m unirun_bench --profile all --samples 1 --duration 0.05 --limit 50000 --json
+        run: uv run python -m unirun_bench --profile all --samples 1 --duration 0.05 --limit 50000 --json

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -14,24 +14,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .
-          pip install pytest git+https://github.com/KMilhan/mutmut.git@ensure-compatibility-with-python-3.14
+      - name: Sync dependencies
+        run: uv sync --group dev --locked --python 3.12
 
       - name: Run mutmut suite
-        run: mutmut run
+        run: uv run mutmut run
 
       - name: Collect mutmut results
         run: |
-          mutmut results > mutation-results.txt
-          python scripts/update_mutation_badge.py --skip-run
+          uv run mutmut results > mutation-results.txt
+          uv run python scripts/update_mutation_badge.py --skip-run
 
       - name: Publish survivability summary
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,15 +22,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.x"
+          python-version: "3.13"
+
+      - name: Create build environment
+        run: uv sync --locked --python 3.13
 
       - name: Build release distributions
-        run: |
-          # NOTE: put your own distribution build steps here.
-          python -m pip install build
-          python -m build
+        run: uv run --with build python -m build
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- replace ad-hoc pip installs in the CI matrix with `uv` plus project make targets for linting, testing, and benchmarks
- rework the mutation survivability workflow to synchronize the dev environment with `uv` before running mutmut and badge refresh steps
- build release artifacts in the publish workflow through a locked `uv` environment to stay consistent with project tooling

## Testing
- not run (local runner lacks pip/uv tooling)


------
https://chatgpt.com/codex/tasks/task_e_68e4a17ab8a4832dad10586f80999787